### PR TITLE
fix(AV-1556): Disable indexing pipeline for fallback field type

### DIFF
--- a/schema.xml
+++ b/schema.xml
@@ -49,14 +49,15 @@ attribute with the form `ckan-X.Y` -->
     <fieldType name="plongs" class="solr.LongPointField" positionIncrementGap="0" multiValued="true"/>
     <fieldType name="pdoubles" class="solr.DoublePointField" positionIncrementGap="0" multiValued="true"/>
 
+    <fieldType name="text_literal" class="solr.TextField" positionIncrementGap="100"/>
     <fieldType name="text" class="solr.TextField" positionIncrementGap="100">
         <analyzer type="index">
+            <filter class="solr.LowerCaseFilterFactory"/>
             <tokenizer class="solr.WhitespaceTokenizerFactory"/>
             <!-- opendata: moved from query -->
             <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
             <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
             <filter class="solr.FlattenGraphFilterFactory"/> <!-- required on index analyzers after graph filters -->
-            <filter class="solr.LowerCaseFilterFactory"/>
             <!--<filter class="solr.SnowballPorterFilterFactory" language="English" protected="protwords.txt"/>-->
             <filter class="solr.ASCIIFoldingFilterFactory"/>
             <filter class="solr.EdgeNGramFilterFactory" minGramSize="3" maxGramSize="30"/>
@@ -176,7 +177,7 @@ attribute with the form `ckan-X.Y` -->
     <dynamicField name="extras_*" type="text" indexed="true" stored="true" multiValued="false"/>
     <dynamicField name="res_extras_*" type="text" indexed="true" stored="true" multiValued="true"/>
     <dynamicField name="vocab_*" type="string" indexed="true" stored="true" multiValued="true"/>
-    <dynamicField name="*" type="text" indexed="true"  stored="false"/>
+    <dynamicField name="*" type="text_literal" indexed="true"  stored="false"/>
 
     <!-- Fields for spatial search -->
     <field name="bbox_area" type="float" indexed="true" stored="true" />


### PR DESCRIPTION
- Added `text_literal` field type for TextFields that should not be processed while indexing
- Made the fallback field `"*"` a `text_literal` to fix edgengrams in user interface